### PR TITLE
Add DigiByte support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [25.07.0] - 2025-07-21
+### Added
+- Initial DigiByte support
+
 ## [25.04.0] - 2025-04-22
 ### Changed
 - Updated Bitcoin client to v29.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.20
-LABEL org.opencontainers.image.title="btc-client"
+LABEL org.opencontainers.image.title="dgb-client"
 LABEL org.opencontainers.image.maintainer="contact@ikna.io"
 LABEL org.opencontainers.image.url="https://www.ikna.io/"
-LABEL org.opencontainers.image.description="Dockerized Bitcoin client"
-LABEL org.opencontainers.image.source="https://github.com/graphsense/btc-client"
+LABEL org.opencontainers.image.description="Dockerized DigiByte client"
+LABEL org.opencontainers.image.source="https://github.com/graphsense/dgb-client"
 
 ARG UID=10000
 
@@ -31,8 +31,8 @@ RUN apk --no-cache --virtual build-dependendencies add \
         grep && \
     cd /tmp; make install && \
     rm -rf /tmp/src && \
-    strip /usr/local/bin/*bitcoin* && \
+    strip /usr/local/bin/*digibyte* && \
     apk del build-dependendencies
 
 USER dockeruser
-CMD ["bitcoind", "-conf=/opt/graphsense/client.conf", "-datadir=/opt/graphsense/data", "-rest"]
+CMD ["digibyted", "-conf=/opt/graphsense/client.conf", "-datadir=/opt/graphsense/data", "-rest"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bitcoin Docker container
+# DigiByte Docker container
 
-A Docker container running [Bitcoin][bitcoin] as a service and exposing
+A Docker container running [DigiByte][digibyte] as a service and exposing
 the REST API.
 
 ## Prerequisites
@@ -12,7 +12,7 @@ Ensure that a user `dockeruser` with ID `10000` exists on your local system.
 
 ## Configuration
 
-Modify `docker/bitcoin.conf` according to your environment
+Modify `docker/client.conf` according to your environment
 (see [doc][bitcoin-conf]).
 
 Configure `rpcallowip=...` to allow the client/daemon to accept
@@ -33,16 +33,16 @@ settings a Docker Compose override file can be used, e.g.
 version: "3.1"
 
 services:
-  bitcoin-client:
+  digibyte-client:
     volumes:
-      - /var/data/graphsense/clients/btc:/opt/graphsense/data
+      - /var/data/graphsense/clients/dgb:/opt/graphsense/data
 ```
 
 The data directory on the host system must be writeable by user `dockeruser`.
 
 ## Usage
 
-Building the docker container (a tagged GitHub version of Bitcoin is
+Building the docker container (a tagged GitHub version of DigiByte is
 specified in `docker/Makefile`):
 
     docker-compose build
@@ -56,6 +56,6 @@ Showing log information:
     docker-compose logs
 
 
-[bitcoin]: https://bitcoin.org
+[digibyte]: https://digibyte.org
 [docker]: https://www.docker.com
 [bitcoin-conf]: https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
 
-  bitcoin-client:
-    image: bitcoin
-    container_name: bitcoin
-    hostname: bitcoin
+  digibyte-client:
+    image: digibyte
+    container_name: digibyte
+    hostname: digibyte
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 install:
-	git clone --depth=1 -b v29.0 https://github.com/bitcoin/bitcoin.git src && \
+        git clone --depth=1 -b v8.22.0 https://github.com/digibyte/digibyte.git src && \
 	cd src && \
 	cmake -B build -DENABLE_WALLET=OFF -DBUILD_UTIL=OFF -DTEST_UTIL=OFF -DBUILD_GUI=OFF && \
 	cmake --build build && \

--- a/docker/client.conf
+++ b/docker/client.conf
@@ -1,4 +1,4 @@
-# server=1 tells Bitcoin-Qt and bitcoind to accept JSON-RPC commands
+# server=1 tells DigiByte-Qt and digibyted to accept JSON-RPC commands
 server=1
 rpcclienttimeout=30
 # By default, only RPC connections from localhost are allowed.
@@ -6,5 +6,5 @@ rpcclienttimeout=30
 # either as a single IPv4/IPv6 or with a subnet specification.
 rpcport=8332
 # API requests need to access non-wallet blockchain transactions by their IDs,
-# following is used enable the transaction index in the Bitcoin Core database
+# following is used enable the transaction index in the DigiByte Core database
 txindex=1


### PR DESCRIPTION
## Summary
- add DigiByte references and service names in README
- update docker-compose for digibyte service
- update Dockerfile labels and command for DigiByte
- build DigiByte from source in docker Makefile
- tweak client.conf and changelog for DigiByte

## Testing
- `make --version`

------
https://chatgpt.com/codex/tasks/task_b_687d89df07d4832ba5fea0d6fae736df